### PR TITLE
fix: honor external BASE_DIR for docker mounts

### DIFF
--- a/V1/entrypoint.sh
+++ b/V1/entrypoint.sh
@@ -67,7 +67,9 @@ setup_symlink() {
 
 init_offline() {
     if [ -f "/usr/local/bin/1pctl" ]; then
-        sed -i "s|BASE_DIR=.*|BASE_DIR=${INT_DIR}|g" /usr/local/bin/1pctl
+        # 1Panel 通过宿主机 docker.sock 创建业务容器，挂载源路径必须写成宿主机真实路径。
+        # 这里要用 BASE_DIR(外部路径)，不能写死成容器内的 /opt。
+        sed -i "s|BASE_DIR=.*|BASE_DIR=${EXT_DIR}|g" /usr/local/bin/1pctl
         sed -i "s|ORIGINAL_PORT=.*|ORIGINAL_PORT=${PORT}|g" /usr/local/bin/1pctl
         sed -i "s|ORIGINAL_ENTRANCE=.*|ORIGINAL_ENTRANCE=/${ENT}|g" /usr/local/bin/1pctl
         sed -i "s|ORIGINAL_USERNAME=.*|ORIGINAL_USERNAME=${USER}|g" /usr/local/bin/1pctl

--- a/V2/entrypoint.sh
+++ b/V2/entrypoint.sh
@@ -67,7 +67,9 @@ setup_symlink() {
 
 init_offline() {
     if [ -f "/usr/local/bin/1pctl" ]; then
-        sed -i "s|BASE_DIR=.*|BASE_DIR=${INT_DIR}|g" /usr/local/bin/1pctl
+        # 1Panel 通过宿主机 docker.sock 创建业务容器，挂载源路径必须写成宿主机真实路径。
+        # 这里要用 BASE_DIR(外部路径)，不能写死成容器内的 /opt。
+        sed -i "s|BASE_DIR=.*|BASE_DIR=${EXT_DIR}|g" /usr/local/bin/1pctl
         sed -i "s|ORIGINAL_PORT=.*|ORIGINAL_PORT=${PORT}|g" /usr/local/bin/1pctl
         sed -i "s|ORIGINAL_ENTRANCE=.*|ORIGINAL_ENTRANCE=/${ENT}|g" /usr/local/bin/1pctl
         sed -i "s|ORIGINAL_USERNAME=.*|ORIGINAL_USERNAME=${USER}|g" /usr/local/bin/1pctl
@@ -105,7 +107,7 @@ init_offline() {
     
     log "同步 Agent 配置..."
     if [ -f "${DATA}/db/agent.db" ]; then
-        update_db_key "${DATA}/db/agent.db" "BaseDir" "${INT_DIR}"
+        update_db_key "${DATA}/db/agent.db" "BaseDir" "${EXT_DIR}"
         update_db_key "${DATA}/db/agent.db" "NodePort" "$PORT"
     fi
 


### PR DESCRIPTION
## Summary
- use external `BASE_DIR` instead of container-internal `/opt` when rewriting `1pctl` at runtime
- update V2 agent `BaseDir` setting to external `BASE_DIR`
- keep V1/V2 docker runtime behavior aligned for host docker.sock mount semantics

## Why
1Panel creates business containers through the host Docker socket, so bind mount source paths must be real host paths. Writing container-internal `/opt` into `1pctl` causes app installs with data mounts to point at the wrong source path when users set a custom `BASE_DIR`.

## Validation
- rebuilt test image from patched source
- verified `1pctl` and `agent.db` both use external `BASE_DIR`
- enabled 1Panel API and installed apps through the real API flow
- confirmed real `n8n` install creates bind mount from host path:
  - source: `/tmp/oc-1panel-v2-test-r2/1panel/apps/n8n/n8nmounttest/data`
  - destination: `/home/node/.n8n`

## Evidence
- commit: `52ba2b8`
- tested branch: `fix/base-dir-mount-compat-20260508`