### PR TITLE
Update V2 Global image and Ubuntu LTS base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,348 +1,103 @@
 # 1Panel Docker 镜像
 
-[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/moelin/1panel/latest?color=%2348BB78&logo=docker&label=version)](https://hub.docker.com/r/moelin/1panel)
+[![Docker Image Version](https://img.shields.io/docker/v/moelin/1panel/latest?color=%2348BB78&logo=docker&label=version)](https://hub.docker.com/r/moelin/1panel)
 [![Docker Pulls](https://img.shields.io/docker/pulls/moelin/1panel?color=%2348BB78&logo=docker&label=pulls)](https://hub.docker.com/r/moelin/1panel)
 [![Docker Stars](https://img.shields.io/docker/stars/moelin/1panel?color=%2348BB78&logo=docker&label=stars)](https://hub.docker.com/r/moelin/1panel)
-[![GitHub Repo stars](https://img.shields.io/github/stars/okxlin/docker-1panel)](https://github.com/okxlin/docker-1panel)
+[![GitHub Stars](https://img.shields.io/github/stars/okxlin/docker-1panel)](https://github.com/okxlin/docker-1panel)
+
+本项目提供 1Panel 的容器化部署镜像，支持 V1/V2、中国版 (CN) 与国际版 (Global/Intl)。镜像基于 Ubuntu LTS 构建，并通过 Supervisor 管理 1Panel 进程。
 
 > [!CAUTION]
-> **重要提示**: 1Panel V2 版本与 V1 版本**无法直接跨版本升级**！
-> 
-> 如需从 V1 迁移到 V2，请参考官方迁移文档: https://1panel.cn/docs/v2/installation/v1_migrate/
-> 
-> **Docker 用户迁移**: 如果您以 Docker 方式运行 V1，可通过迁移脚本先切换到宿主机运行模式，再使用官方升级工具升级到 V2，最后可切换回 Docker 运行模式。详见 [Q2: 如何从 V1 迁移到 V2?](#q2-如何从-v1-迁移到-v2)
->
-> 脚本下载链接:
-> [GitHub](https://raw.githubusercontent.com/okxlin/ToolScript/refs/heads/main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [cdn.jsdelivr.net](https://cdn.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [testingcf.jsdelivr.net](https://testingcf.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [quantil.jsdelivr.net](https://quantil.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [fastly.jsdelivr.net](https://fastly.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [purge.jsdelivr.net](https://purge.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [gcore.jsdelivr.net](https://gcore.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh) |
-> [originfastly.jsdelivr.net](https://originfastly.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh)
+> 1Panel V1 与 V2 无法直接跨版本升级。已有 V1 数据需要迁移到 V2 时，请先阅读官方迁移文档：<https://1panel.cn/docs/v2/installation/v1_migrate/>
 
-## 📑 目录
+## 版本与镜像
 
-- [简介](#简介)
-- [版本说明](#版本说明)
-- [镜像标签](#镜像标签)
-- [V1 版本使用](#v1-版本使用)
-  - [注意事项](#v1-注意事项)
-  - [Docker 安装](#v1-docker-安装)
-  - [Docker Compose 安装](#v1-docker-compose-安装)
-  - [环境变量配置](#v1-环境变量配置)
-  - [修改面板显示版本](#修改面板显示版本)
-- [V2 版本使用](#v2-版本使用)
-  - [注意事项](#v2-注意事项)
-  - [Docker 安装](#v2-docker-安装)
-  - [Docker Compose 安装](#v2-docker-compose-安装)
-  - [环境变量配置](#环境变量配置)
-- [镜像编译](#镜像编译)
-- [常见问题](#常见问题)
-- [相关链接](#相关链接)
-- [声明](#声明)
+| 系列 | 版本源 | Dockerfile | 最新源 | 适用场景 |
+| --- | --- | --- | --- | --- |
+| V1 CN | `resource.fit2cloud.com` | `V1/Dockerfile` | `v1.10.34-lts` | 继续维护已有 V1 部署 |
+| V1 Global | `resource.1panel.pro` | `V1/Dockerfile-Global` | `v1.10.34-lts` | 继续维护已有国际版 V1 部署 |
+| V2 CN | `resource.fit2cloud.com/1panel/package/v2` | `V2/Dockerfile` | `v2.2.2` | 新部署推荐 |
+| V2 Global | `resource.1panel.pro/v2` | `V2/Dockerfile-Global` | `v2.2.2` | 新部署国际版推荐 |
 
----
+基础镜像：`ubuntu:26.04`
 
-## 简介
+常用标签：
 
-本项目提供 1Panel 的 Docker 容器化部署方案，支持 V1 和 V2 两个主要版本。
-
-**项目特点**:
-- ✅ 支持多架构平台 (amd64, arm64, armv7, ppc64le, s390x)
-- ✅ 自动化构建和版本更新
-- ✅ 提供中国版 (CN) 和国际版 (Global) 镜像
-- ✅ V1/V2 版本均支持环境变量配置 (V1 需 v1.10.34-lts+)
-- ✅ 云原生架构: Supervisor 进程管理 + 动态配置
-
-**致谢**: 本项目受 [1panel-dood](https://github.com/tangger2000/1panel-dood) 启发，采用替换二进制文件的方式实现容器化部署。
-
----
-
-## 版本说明
-
-| 版本 | 下载源 | 状态 | 推荐使用 |
-|------|--------|------|----------|
-| **V1** | 国内/国际 | 维护中 | 稳定用户 |
-| **V2** | 国内 | 最新版 | 新用户 |
-
-> [!WARNING]
-> V1 和 V2 **无法直接跨版本升级**，迁移请参考: https://1panel.cn/docs/v2/installation/v1_migrate/
-
----
-
-## 镜像标签
-
-### V1 中国版 (CN)
 ```bash
-moelin/1panel:v1.10.22    # 具体版本
-moelin/1panel:v1          # 浮动标签 (最新 V1)
+# V1 CN
+moelin/1panel:v1.10.34-lts
+moelin/1panel:v1
+
+# V1 Global
+moelin/1panel:global-v1.10.34-lts
+moelin/1panel:global-v1
+
+# V2 CN
+moelin/1panel:v2.2.2
+moelin/1panel:v2
+moelin/1panel:latest
+
+# V2 Global
+moelin/1panel:global-v2.2.2
+moelin/1panel:global-v2
 ```
 
-### V1 国际版 (Global)
-```bash
-moelin/1panel:global-v1.10.22    # 具体版本
-moelin/1panel:global-v1          # 浮动标签 (最新 V1 Global)
-```
+生产环境建议固定到具体版本号；测试环境可使用 `v1`、`v2`、`global-v1`、`global-v2` 等浮动标签。
 
-### V2 中国版 (CN)
-```bash
-moelin/1panel:v2.0.6      # 具体版本
-moelin/1panel:v2          # 浮动标签 (最新 V2)
-moelin/1panel:latest      # 全局最新 (指向 V2)
-```
+## 部署
 
-> [!TIP]
-> **标签选择建议**
-> - 生产环境: 使用具体版本号 (如 `v1.10.22`)
-> - 测试环境: 使用浮动标签 (如 `v1`, `v2`)
-> - 追求最新: 使用 `latest` (目前指向 V2)
+### Docker Run
 
----
+V2 CN：
 
-## V1 版本使用
-
-### V1 注意事项
-
-> [!IMPORTANT]
-> **使用限制**
-> - **禁止**点击面板右下角更新按钮
-> - 应通过拉取新镜像并重新部署来更新
-
-> [!NOTE]
-> **云原生架构升级** (v1.10.34-lts+)
-> - ✅ 支持环境变量动态配置 (端口、用户名、密码、入口)
-> - ✅ Supervisor 进程管理，自动重启和日志管理
-> - ✅ 首次启动自动配置，支持随机密码生成
-> - ⚠️ **仅 v1.10.34-lts 及以后版本支持**环境变量配置功能
-
-**默认配置**:
-- 端口: `10086`
-- 账户: `1panel`
-- 密码: `1panel_password` (首次启动可自动生成随机密码)
-- 入口: `entrance`
-
-**支持架构**: amd64, arm64, armv7, ppc64le, s390x
-
-### V1 Docker 安装
-
-#### 中国版 (CN) - 基础安装
 ```bash
 docker run -d \
-    --name 1panel \
-    --restart always \
-    --network host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/lib/docker/volumes:/var/lib/docker/volumes \
-    -v /opt:/opt \
-    -v /root:/root \
-    -e TZ=Asia/Shanghai \
-    moelin/1panel:v1
+  --name 1panel-v2 \
+  --restart always \
+  --network host \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /opt:/opt \
+  -e TZ=Asia/Shanghai \
+  -e PORT=10086 \
+  -e USERNAME=admin \
+  -e PASSWORD=your_secure_password \
+  -e ENTRANCE=myentrance \
+  moelin/1panel:v2
 ```
 
-#### 中国版 (CN) - 自定义配置 (v1.10.34-lts+)
+V2 Global：
+
 ```bash
 docker run -d \
-    --name 1panel \
-    --restart always \
-    --network host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/lib/docker/volumes:/var/lib/docker/volumes \
-    -v /opt:/opt \
-    -v /root:/root \
-    -e TZ=Asia/Shanghai \
-    -e PORT=10086 \
-    -e USERNAME=admin \
-    -e PASSWORD=your_secure_password \
-    -e ENTRANCE=myentrance \
-    moelin/1panel:v1
+  --name 1panel-v2-global \
+  --restart always \
+  --network host \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /opt:/opt \
+  -e TZ=Asia/Shanghai \
+  -e PORT=10086 \
+  -e USERNAME=admin \
+  -e PASSWORD=your_secure_password \
+  -e ENTRANCE=myentrance \
+  moelin/1panel:global-v2
 ```
 
-#### 国际版 (Global) - 基础安装
+V1 仍可使用相同运行方式，只需把镜像替换为 `moelin/1panel:v1` 或 `moelin/1panel:global-v1`。V1 如需完整兼容旧部署，可继续挂载 `/var/lib/docker/volumes` 与 `/root`：
+
 ```bash
-docker run -d \
-    --name 1panel-global \
-    --restart always \
-    --network host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/lib/docker/volumes:/var/lib/docker/volumes \
-    -v /opt:/opt \
-    -v /root:/root \
-    -e TZ=Asia/Shanghai \
-    moelin/1panel:global-v1
+-v /var/lib/docker/volumes:/var/lib/docker/volumes \
+-v /root:/root
 ```
 
-#### 国际版 (Global) - 自定义配置 (v1.10.34-lts+)
-```bash
-docker run -d \
-    --name 1panel-global \
-    --restart always \
-    --network host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/lib/docker/volumes:/var/lib/docker/volumes \
-    -v /opt:/opt \
-    -v /root:/root \
-    -e TZ=Asia/Shanghai \
-    -e PORT=10086 \
-    -e USERNAME=admin \
-    -e PASSWORD=your_secure_password \
-    -e ENTRANCE=myentrance \
-    moelin/1panel:global-v1
-```
-
-### V1 Docker Compose 安装
-
-#### 基础配置
-
-创建 `docker-compose.yml`:
+### Docker Compose
 
 ```yaml
-version: '3'
 services:
   1panel:
-    container_name: 1panel
-    restart: always
-    network_mode: "host"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/lib/docker/volumes:/var/lib/docker/volumes
-      - /opt:/opt
-      - /root:/root
-    environment:
-      - TZ=Asia/Shanghai
-    image: moelin/1panel:v1
-    labels:
-      createdBy: "Apps"
-```
-
-#### 自定义配置 (v1.10.34-lts+)
-
-```yaml
-version: '3'
-services:
-  1panel:
-    container_name: 1panel
-    restart: always
-    network_mode: "host"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/lib/docker/volumes:/var/lib/docker/volumes
-      - /opt:/opt
-      - /root:/root
-    environment:
-      - TZ=Asia/Shanghai
-      - PORT=10086
-      - USERNAME=admin
-      - PASSWORD=your_secure_password
-      - ENTRANCE=myentrance
-      - BASE_DIR=/opt
-    image: moelin/1panel:v1
-    labels:
-      createdBy: "Apps"
-```
-
-运行:
-```bash
-docker-compose up -d
-```
-
-### V1 环境变量配置
-
-> [!WARNING]
-> **版本要求**: 环境变量配置功能仅在 **v1.10.34-lts** 及以后版本生效
-
-| 变量名 | 默认值 | 说明 |
-|--------|--------|------|
-| `PORT` | `10086` | 面板访问端口 |
-| `USERNAME` | `1panel` | 管理员用户名 |
-| `PASSWORD` | `1panel_password` | 管理员密码 (首次启动自动生成随机密码) |
-| `ENTRANCE` | `entrance` | 安全入口路径 |
-| `BASE_DIR` | `/opt` | 数据存储目录 |
-| `TZ` | `Asia/Shanghai` | 时区设置 |
-| `RESET` | `false` | 设为 `true` 强制重置配置 |
-
-> [!TIP]
-> **密码安全提示**
-> - 如果不设置 `PASSWORD` 或使用默认值，首次启动会自动生成随机密码
-> - 随机密码会在容器日志中显示，请及时查看并保存
-> - 查看日志: `docker logs 1panel`
-
-### 修改面板显示版本
-
-> [!NOTE]
-> 自 2023-09-19 起，镜像已支持自动修改面板显示版本，**无需手动操作**
-
-如需手动修改:
-
-#### 1. 安装 SQLite3
-
-```bash
-# Debian/Ubuntu
-apt-get update && apt-get install sqlite3 -y
-
-# RedHat/CentOS
-yum install sqlite -y
-```
-
-#### 2. 修改版本信息
-
-```bash
-# 备份数据库
-cp /opt/1panel/db/1Panel.db /opt/1panel/db/1Panel.db.bak
-
-# 打开数据库
-sqlite3 /opt/1panel/db/1Panel.db
-
-# 修改版本 (替换 v1.10.22 为实际版本)
-UPDATE settings SET value = 'v1.10.22' WHERE key = 'SystemVersion';
-
-# 退出
-.exit
-
-# 重启容器
-docker restart 1panel
-```
-
----
-
-## V2 版本使用
-
-### V2 注意事项
-
-- ✅ 支持通过环境变量配置端口、用户名、密码、入口
-- ✅ 支持数据目录映射 (`BASE_DIR`)
-- ✅ 首次启动自动配置，无需手动初始化
-- ⚠️ **无法从 V1 直接升级**，迁移请参考官方文档
-
-### V2 Docker 安装
-
-```bash
-docker run -d \
-    --name 1panel-v2 \
-    --restart always \
-    --network host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /opt:/opt \
-    -e TZ=Asia/Shanghai \
-    -e PORT=10086 \
-    -e USERNAME=admin \
-    -e PASSWORD=your_secure_password \
-    -e ENTRANCE=myentrance \
-    moelin/1panel:v2
-```
-
-### V2 Docker Compose 安装
-
-创建 `docker-compose.yml`:
-
-```yaml
-version: '3'
-services:
-  1panel-v2:
+    image: moelin/1panel:v2
     container_name: 1panel-v2
     restart: always
-    network_mode: "host"
+    network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /opt:/opt
@@ -353,164 +108,166 @@ services:
       - PASSWORD=your_secure_password
       - ENTRANCE=myentrance
       - BASE_DIR=/opt
-    image: moelin/1panel:v2
     labels:
-      createdBy: "Apps"
+      createdBy: Apps
 ```
 
-运行:
+启动：
+
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
-### 环境变量配置
+如需国际版 V2，将 `image` 改为：
 
-| 变量名 | 默认值 | 说明 |
-|--------|--------|------|
+```yaml
+image: moelin/1panel:global-v2
+```
+
+## 环境变量
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
 | `PORT` | `10086` | 面板访问端口 |
 | `USERNAME` | `1panel` | 管理员用户名 |
-| `PASSWORD` | `1panel_password` | 管理员密码 (首次启动自动生成随机密码) |
-| `ENTRANCE` | `entrance` | 安全入口路径 |
-| `BASE_DIR` | `/opt` | 数据存储目录 |
-| `TZ` | `Asia/Shanghai` | 时区设置 |
-| `RESET` | `false` | 设为 `true` 强制重置配置 |
+| `PASSWORD` | `1panel_password` | 管理员密码；空值或默认值会在首次启动时生成随机密码 |
+| `ENTRANCE` | `entrance` | 安全入口路径，不需要前后 `/` |
+| `BASE_DIR` | `/opt` | 1Panel 数据目录。映射到宿主机时应填写宿主机真实路径 |
+| `TZ` | `Asia/Shanghai` | 容器时区 |
+| `RESET` | `false` | 设为 `true` 可在启动时重置账号、密码、端口和入口 |
 
-> [!TIP]
-> **密码安全提示**
-> - 如果不设置 `PASSWORD` 或使用默认值，首次启动会自动生成随机密码
-> - 随机密码会在容器日志中显示，请及时查看并保存
-> - 查看日志: `docker logs 1panel-v2`
-
----
-
-## 镜像编译
-
-### V1 编译
+随机密码会输出到容器日志：
 
 ```bash
-# 单架构编译
-docker build --build-arg PANELVER=v1.10.22 -t 1panel:v1.10.22 ./V1
-
-# 多架构编译并推送
-docker buildx build \
-  --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x \
-  --build-arg PANELVER=v1.10.22 \
-  -t <your-dockerhub-username>/1panel:v1.10.22 \
-  --push \
-  ./V1
+docker logs 1panel-v2
 ```
 
-### V1 Global 编译
+> [!IMPORTANT]
+> V1 环境变量配置仅适用于 `v1.10.34-lts` 及之后版本。旧版本 V1 请按原有方式部署和维护。
+
+## 旧数据与密码重置
+
+容器启动时会用数据目录里的 `.docker_initialized` 判断是否已经完成过 Docker 初始化。默认数据目录是 `/opt/1panel`；如果设置了 `BASE_DIR=/data`，对应宿主机路径就是 `/data/1panel/.docker_initialized`。
+
+已有旧数据时，如果数据库存在但没有这个标记文件，入口脚本会按“首次初始化”处理，并根据 `USERNAME`、`PASSWORD`、`PORT`、`ENTRANCE` 重新配置账号、密码、端口和入口。为了保留旧账号密码，请在启动新容器前确认标记文件存在：
 
 ```bash
-docker buildx build \
-  --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x \
-  --build-arg PANELVER=v1.10.22 \
-  -t <your-dockerhub-username>/1panel:global-v1.10.22 \
-  -f ./V1/Dockerfile-Global \
-  --push \
-  ./V1
+# 默认 BASE_DIR=/opt
+touch /opt/1panel/.docker_initialized
+
+# 自定义 BASE_DIR=/data 时
+touch /data/1panel/.docker_initialized
 ```
 
-### V2 编译
+同时不要设置 `RESET=true`。`RESET=true` 会强制重新配置账号、密码、端口和入口，即使 `.docker_initialized` 已存在。
+
+数据库文件位置：
+
+```bash
+# V1
+/opt/1panel/db/1Panel.db
+
+# V2
+/opt/1panel/db/core.db
+/opt/1panel/db/agent.db
+```
+
+## 编译
+
+单架构本地构建：
+
+```bash
+# V2 CN
+docker build -t 1panel:v2 ./V2
+
+# V2 Global
+docker build -f ./V2/Dockerfile-Global -t 1panel:global-v2 ./V2
+```
+
+指定版本：
+
+```bash
+docker build \
+  --build-arg PANELVER=v2.2.2 \
+  -t 1panel:v2.2.2 \
+  ./V2
+
+docker build \
+  -f ./V2/Dockerfile-Global \
+  --build-arg PANELVER=v2.2.2 \
+  -t 1panel:global-v2.2.2 \
+  ./V2
+```
+
+多架构构建并推送：
 
 ```bash
 docker buildx build \
   --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x \
-  --build-arg PANELVER=v2.0.6 \
-  -t <your-dockerhub-username>/1panel:v2.0.6 \
+  --build-arg PANELVER=v2.2.2 \
+  -t <your-dockerhub-username>/1panel:v2.2.2 \
+  -t <your-dockerhub-username>/1panel:v2 \
+  --push \
+  ./V2
+
+docker buildx build \
+  --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x \
+  -f ./V2/Dockerfile-Global \
+  --build-arg PANELVER=v2.2.2 \
+  -t <your-dockerhub-username>/1panel:global-v2.2.2 \
+  -t <your-dockerhub-username>/1panel:global-v2 \
   --push \
   ./V2
 ```
 
----
+V1 构建：
+
+```bash
+docker build --build-arg PANELVER=v1.10.34-lts -t 1panel:v1 ./V1
+docker build -f ./V1/Dockerfile-Global --build-arg PANELVER=v1.10.34-lts -t 1panel:global-v1 ./V1
+```
 
 ## 常见问题
 
-### Q1: V1 和 V2 如何选择?
+### V1 和 V2 如何选择？
 
-**V1 适合**:
-- 已有 V1 部署且运行稳定
-- 不需要最新功能
-- 追求稳定性
+新部署建议使用 V2。已有 V1 部署如果运行稳定，可继续使用 V1 镜像维护；迁移到 V2 前请先备份并按官方迁移流程执行。
 
-**V2 适合**:
-- 新用户首次部署
-- 需要最新功能和性能优化
-- 愿意接受新架构
+### 如何从 Docker 方式的 V1 迁移到 V2？
 
-### Q2: 如何从 V1 迁移到 V2?
-
-> [!CAUTION]
-> **无法直接升级！**
-
-请参考官方迁移文档: https://1panel.cn/docs/v2/installation/v1_migrate/
-
-> [!TIP]
-> **Docker 运行模式迁移方案**
->
-> 如果您当前以 Docker 方式运行 1Panel V1，可以通过以下步骤迁移到 V2:
->
-> **步骤 1**: 使用迁移脚本将 1Panel 从 Docker 运行模式切换到宿主机运行模式
-> ```bash
-> # GitHub 源
-> wget -O 1panel_docker_to_sys.sh https://raw.githubusercontent.com/okxlin/ToolScript/refs/heads/main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> # jsDelivr 源 (以下任选其一，国内加速)
-> wget -O 1panel_docker_to_sys.sh https://cdn.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> wget -O 1panel_docker_to_sys.sh https://testingcf.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> wget -O 1panel_docker_to_sys.sh https://quantil.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> wget -O 1panel_docker_to_sys.sh https://fastly.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> wget -O 1panel_docker_to_sys.sh https://purge.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> wget -O 1panel_docker_to_sys.sh https://gcore.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> wget -O 1panel_docker_to_sys.sh https://originfastly.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
-> # 下载完成后，添加执行权限并运行
-> chmod +x 1panel_docker_to_sys.sh && bash 1panel_docker_to_sys.sh
-> ```
->
-> **步骤 2**: 使用官方升级工具将 V1 升级到 V2
-> - 参考官方文档: https://1panel.cn/docs/v2/installation/v1_migrate/
->
-> **步骤 3**: 升级完成后，如需切换回 Docker 运行模式，可重新使用迁移脚本切换回 Docker 运行模式
-
-### Q3: 容器内如何执行 1pctl 命令?
+可以先用迁移脚本将 V1 从 Docker 运行模式切换到宿主机运行模式，再按官方文档升级到 V2：
 
 ```bash
-# 进入容器
-docker exec -it 1panel bash
-
-# V1 执行命令
-1pctl version
-
-# V2 执行命令
-1pctl version
+wget -O 1panel_docker_to_sys.sh https://raw.githubusercontent.com/okxlin/ToolScript/refs/heads/main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
+chmod +x 1panel_docker_to_sys.sh
+bash 1panel_docker_to_sys.sh
 ```
 
-### Q4: 如何查看容器日志?
+国内网络可将下载地址替换为 jsDelivr 镜像：
 
 ```bash
-# V1
-docker logs 1panel
-
-# V2
-docker logs 1panel-v2
-
-# 实时查看
-docker logs -f 1panel-v2
+https://cdn.jsdelivr.net/gh/okxlin/ToolScript@main/1Panel/1panel-execution-mode/1panel_docker_to_sys.sh
 ```
 
----
+官方迁移文档：<https://1panel.cn/docs/v2/installation/v1_migrate/>
+
+### 容器内如何执行 1pctl？
+
+```bash
+docker exec -it 1panel-v2 bash
+1pctl version
+1pctl user-info
+```
+
+### 为什么不建议在面板里直接点升级？
+
+容器镜像内包含特定版本的 1Panel 二进制与初始化文件。升级时建议拉取新镜像并重新部署，避免容器内升级后的文件状态与镜像版本不一致。
 
 ## 相关链接
 
-- [1Panel 官网](https://1panel.cn)
-- [1Panel 文档](https://1panel.cn/docs)
+- [1Panel 中国官网](https://1panel.cn)
+- [1Panel 国际站](https://1panel.pro)
 - [1Panel GitHub](https://github.com/1Panel-dev/1Panel)
 - [Docker Hub](https://hub.docker.com/r/moelin/1panel)
 - [本项目 GitHub](https://github.com/okxlin/docker-1panel)
 - [应用商店适配库](https://github.com/okxlin/appstore)
-
----
-
-## 声明
-
-本项目部分文档内容由 AI 辅助生成。

--- a/V1/Dockerfile
+++ b/V1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG INSTALL_MODE="stable"

--- a/V2/1pctl
+++ b/V2/1pctl
@@ -3,14 +3,16 @@
 action=$1
 target=$2
 args=$@
+extra_args=("${@:3}")
 
 BASE_DIR=directory
 ORIGINAL_PORT=port
-ORIGINAL_VERSION=v2.0.15
+ORIGINAL_VERSION=v2.2.2
 ORIGINAL_ENTRANCE=entrance
 ORIGINAL_USERNAME=username
 ORIGINAL_PASSWORD=password
 LANGUAGE=en
+PANEL_EDITION=cn
 
 if [ -f "/usr/local/bin/lang/$LANGUAGE.sh" ]; then
     source "/usr/local/bin/lang/$LANGUAGE.sh"
@@ -65,6 +67,7 @@ function usage() {
     echo -e "  ${GREEN}restart${NC} [core|agent|all]    ${YELLOW}$TXT_PANEL_SERVICE_RESTART${NC}"
     echo -e "  ${RED}uninstall${NC}                   ${YELLOW}$TXT_PANEL_SERVICE_UNINSTALL${NC}"
     echo -e "  ${GREEN}user-info${NC}                   ${YELLOW}$TXT_PANEL_SERVICE_USER_INFO${NC}"
+    echo -e "  ${GREEN}user-list${NC}                   ${YELLOW}$TXT_PANEL_SERVICE_USER_LIST${NC}"
     echo -e "  ${GREEN}listen-ip${NC}                   ${YELLOW}$TXT_PANEL_SERVICE_LISTEN_IP${NC}"
     echo -e "  ${GREEN}version${NC}                     ${YELLOW}$TXT_PANEL_SERVICE_VERSION${NC}"
     echo -e "  ${GREEN}update${NC}                      ${YELLOW}$TXT_PANEL_SERVICE_UPDATE${NC}"
@@ -288,6 +291,12 @@ function user-info() {
     generate_border_line 60 "-" "$BLUE"
 }
 
+function user-list() {
+    print_centered_title "$TXT_PANEL_SERVICE_USER_LIST" 60 "=" "$BLUE"
+    1panel -l $LANGUAGE user-list
+    generate_border_line 60 "-" "$BLUE"
+}
+
 function listen-ip() {
     print_centered_title "$TXT_PANEL_SERVICE_LISTEN_IP" 60 "=" "$BLUE"
     case "${target}" in
@@ -312,6 +321,19 @@ function restore() {
     print_centered_title "$TXT_PANEL_SERVICE_RESTORE" 60 "=" "$YELLOW"
     check_root
     while true; do
+        read -p "$TXT_PANEL_SERVICE_RESTORE_NODE_NOTICE" yn
+        case "$yn" in
+            [Yy])
+                ;;
+            [Nn])
+                exit 0
+                ;;
+            *)
+                echo -e "$TXT_INVALID_YN_INPUT"
+                continue
+                ;;
+        esac
+
         read -p "$TXT_PANEL_SERVICE_RESTORE_NOTICE" yn
         case "$yn" in
             [Yy])
@@ -355,7 +377,10 @@ function reset() {
             1panel -l $LANGUAGE reset ips
             ;;
         mfa)
-            1panel -l $LANGUAGE reset mfa
+            1panel -l $LANGUAGE reset mfa ${extra_args[@]}
+            ;;
+        passkey)
+            1panel -l $LANGUAGE reset passkey
             ;;
         *)
             1panel -l $LANGUAGE reset
@@ -369,10 +394,10 @@ function update() {
     check_root
     case "${target}" in
         username)
-            1panel -l $LANGUAGE update username
+            1panel -l $LANGUAGE update username ${extra_args[@]}
             ;;
         password)
-            1panel -l $LANGUAGE update password
+            1panel -l $LANGUAGE update password ${extra_args[@]}
             ;;
         port)
             1panel -l $LANGUAGE update port
@@ -406,6 +431,9 @@ function main() {
             ;;
         user-info)
             user-info
+            ;;
+        user-list)
+            user-list
             ;;
         listen-ip)
             listen-ip

--- a/V2/Dockerfile
+++ b/V2/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:22.04
+FROM ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG INSTALL_MODE="stable"
 ARG PANELVER=""
+ARG PANEL_EDITION="cn"
 ENV TZ=Asia/Shanghai
 
 LABEL org.opencontainers.image.version="${PANELVER}" \
@@ -47,6 +48,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
     rm package.tar.gz && \
     mv /app/1pctl.custom /app/1pctl && \
     sed -i "s|ORIGINAL_VERSION=.*|ORIGINAL_VERSION=${PANELVER}|g" /app/1pctl && \
+    sed -i "s|^PANEL_EDITION=.*|PANEL_EDITION=${PANEL_EDITION}|g" /app/1pctl && \
     chmod +x 1pctl && \
     bash install-v2.override.sh && \
     mkdir -p /opt/1panel/tmp /opt/1panel/db /opt/1panel/log && \

--- a/V2/Dockerfile-Global
+++ b/V2/Dockerfile-Global
@@ -3,13 +3,14 @@ FROM ubuntu:26.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG INSTALL_MODE="stable"
 ARG PANELVER=""
+ARG PANEL_EDITION="intl"
 ENV TZ=Asia/Shanghai
 
 LABEL org.opencontainers.image.version="${PANELVER}" \
-      org.opencontainers.image.source="https://github.com/okxlin/docker-1panel" \
-      org.opencontainers.image.description="1Panel Global Edition Docker Image" \
-      org.opencontainers.image.title="1Panel Global" \
-      org.opencontainers.image.vendor="okxlin"
+    org.opencontainers.image.source="https://github.com/okxlin/docker-1panel" \
+    org.opencontainers.image.description="1Panel V2 Global Edition Docker Image" \
+    org.opencontainers.image.title="1Panel V2 Global" \
+    org.opencontainers.image.vendor="okxlin"
 
 RUN apt-get update && apt-get install -y \
     curl wget tar unzip zip git sudo gnupg sqlite3 tzdata \
@@ -27,40 +28,42 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 COPY ./1pctl /app/1pctl.custom
-COPY ./install-v1.override.sh /app/install-v1.override.sh
+COPY ./install-v2.override.sh /app/install-v2.override.sh
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 RUN chmod +x /usr/local/bin/entrypoint.sh && \
-    chmod +x /app/install-v1.override.sh && \
+    chmod +x /app/install-v2.override.sh && \
     if [ -z "$PANELVER" ]; then \
-        PANELVER=$(curl -s https://resource.1panel.pro/stable/latest); \
+    PANELVER=$(curl -s https://resource.1panel.pro/v2/${INSTALL_MODE}/latest); \
     fi && \
     ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "armhf" ]; then ARCH="armv7"; fi && \
     if [ "$ARCH" = "ppc64el" ]; then ARCH="ppc64le"; fi && \
     PKG_NAME="1panel-${PANELVER}-linux-${ARCH}.tar.gz" && \
-    PKG_URL="https://resource.1panel.pro/${INSTALL_MODE}/${PANELVER}/release/${PKG_NAME}" && \
+    PKG_URL="https://resource.1panel.pro/v2/${INSTALL_MODE}/${PANELVER}/release/${PKG_NAME}" && \
     echo "Downloading ${PKG_URL}..." && \
     curl -sSL -o package.tar.gz "$PKG_URL" && \
     tar zxvf package.tar.gz --strip-components 1 && \
     rm package.tar.gz && \
     mv /app/1pctl.custom /app/1pctl && \
     sed -i "s|ORIGINAL_VERSION=.*|ORIGINAL_VERSION=${PANELVER}|g" /app/1pctl && \
+    sed -i "s|^PANEL_EDITION=.*|PANEL_EDITION=${PANEL_EDITION}|g" /app/1pctl && \
     chmod +x 1pctl && \
-    bash install-v1.override.sh && \
+    bash install-v2.override.sh && \
     mkdir -p /opt/1panel/tmp /opt/1panel/db /opt/1panel/log && \
     mkdir -p /usr/share/1panel-default && \
     echo "Pre-generating database..." && \
-    (timeout 10s /usr/local/bin/1panel || true) && \
-    if [ -f /opt/1panel/db/1Panel.db ]; then \
-        echo "Database generated successfully." && \
-        mv /opt/1panel/* /usr/share/1panel-default/; \
-        rm -rf /opt/1panel/*; \
+    (timeout 10s /usr/local/bin/1panel-core || true) && \
+    (timeout 5s /usr/local/bin/1panel-agent || true) && \
+    if [ -f /opt/1panel/db/core.db ] && [ -f /opt/1panel/db/agent.db ]; then \
+    echo "Database generated successfully." && \
+    mv /opt/1panel/* /usr/share/1panel-default/; \
+    rm -rf /opt/1panel/*; \
     else \
-        echo "Error: Database generation failed. Core log:" && \
-        cat /opt/1panel/log/* || true && \
-        exit 1; \
+    echo "Error: Database generation failed. Core log:" && \
+    cat /opt/1panel/log/* || true && \
+    exit 1; \
     fi && \
     rm -rf /app/*
 

--- a/V2/entrypoint.sh
+++ b/V2/entrypoint.sh
@@ -102,6 +102,7 @@ init_offline() {
     
     log "同步 Core 配置..."
     if [ -f "${DATA}/db/core.db" ]; then
+        update_db_key "${DATA}/db/core.db" "ServerPort" "$PORT"
         update_db_key "${DATA}/db/core.db" "SystemPort" "$PORT"
     fi
     
@@ -126,7 +127,7 @@ init_offline() {
 }
 
 config_online() {
-    CURRENT_PORT=$(sqlite3 "${DATA}/db/core.db" "SELECT value FROM settings WHERE key='SystemPort';")
+    CURRENT_PORT=$(sqlite3 "${DATA}/db/core.db" "SELECT value FROM settings WHERE key='ServerPort';")
     CURRENT_PORT=${CURRENT_PORT:-10086}
     
     log "等待服务启动 (端口: $CURRENT_PORT)..."
@@ -157,23 +158,20 @@ config_online() {
 set timeout 30
 spawn /usr/local/bin/1pctl update username
 expect {
+    "Update user information:" { send "$USER\r" }
     "user:" { send "$USER\r" }
     timeout { exit 1 }
 }
 expect eof
 spawn /usr/local/bin/1pctl update password
 expect {
+    "Update user password:" { send "$PASS\r" }
     "password:" { send "$PASS\r" }
     timeout { exit 1 }
 }
 expect {
+    "Update user password:" { send "$PASS\r" }
     "password:" { send "$PASS\r" }
-    timeout { exit 1 }
-}
-expect eof
-spawn /usr/local/bin/1pctl update port
-expect {
-    "port:" { send "$PORT\r" }
     timeout { exit 1 }
 }
 expect eof


### PR DESCRIPTION
Update Ubuntu base image to 26.04, add V2 Global Dockerfile using the official intl v2 source, refresh V2 control script metadata, and reorganize README usage/build docs.